### PR TITLE
Allowing for multiple conda enviroment definitions.

### DIFF
--- a/{{ cookiecutter.repo_name }}/conda-envs/environment.{{ cookiecutter.repo_name }}-docs.yml
+++ b/{{ cookiecutter.repo_name }}/conda-envs/environment.{{ cookiecutter.repo_name }}-docs.yml
@@ -1,7 +1,7 @@
-name: docs
+name: {{ cookiecutter.repo_name }}-docs
 channels:
-  - defaults
-  - conda-forge
+   - defaults
+   - conda-forge
 dependencies:
   - pip
   - sphinx
@@ -12,3 +12,9 @@ dependencies:
   - sphinx-autoapi
   - myst-parser
   - pre-commit
+  - cruft
+  - flake8
+  - black
+  - autoflake
+  - pre-commit
+


### PR DESCRIPTION
#### This pull request, solves four concerns  

1. Allowing multiple conda environment definitions. Escenarios when this could be a good idea:

- Multiple apps: projects with multiple components using different environments. 
- Versioning: specifying multiple version of dependencies 
- OS: different operative system

2. Specify  an ```environment.docs.yml``` relevant to work with documentation generation or other basic data science-cookiecutter dependencies. Not really relevant to the new project. (Separation of business logic) 

3. ~~Fixes the problem that the “default” **environment.yml** doesn’t work on Mac (osx). Allowing to have multiple environments could potentially solve the issue of environment versions based on OS. It allows to specify different environment using either conda dependencies or pip dependencies. Some OS don’t have a particular packages at pip level but yes as a conda package. 
Note: I also tried the current default **environment.yml** with a mini Ubuntu distribution and it didn’t work too~~
This was fixed by adding the ```conda-forge``` channel to ```environment.docs.yml```. It works on Mac and Linux. 


4. Update the environment.docs.yml given that the package sphinx-autoapi is missing.

#### Actions 

 - copied ```environment.yml``` to ```conda-envs/environment.docs.yml```. 

 - added ```name: docs``` to ```conda-envs/environment.docs.yml```.
 - added dependency ``` - sphinx-autoapi``` to ```conda-envs/environment.docs.yaml```


#### Location & Name convention (Proposal)
```
conda-envs/environment.{env-name}.{win|osx}.yml
```

@chritter @ToucheSir @goatsweater (We can continue the discussion relating to multiple conda envs here also this fixes issue/20) 
