### PR TITLE
Added pre-commit hooks: autoflake, black

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -28,12 +28,17 @@ repos:
         types: [ cython, pyi, python ]
         args: [ "--profile", "black", "--filter-files" ]
   # Unclear if black is going to be used.
-  # - repo: https://github.com/psf/black
-  #   rev: 21.5b2 # Replace by any tag/version: https://github.com/psf/black/tags
-  #   hooks:
-  #     - id: black
-  #       name: black - consistent Python code formatting (auto-fixes)
-  #       language_version: python # Should be a command that runs python3.6+
+  - repo: https://github.com/psf/black
+    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    hooks:
+      - id: black
+        name: black - consistent Python code formatting (auto-fixes)
+        language_version: python # Should be a command that runs python3.6+
+  - repo: https://github.com/myint/autoflake
+    rev: v1.4
+    hooks:
+      - id: autoflake
+        args: ['--in-place', '--remove-all-unused-imports', '--ignore-init-module-imports']
   - repo: https://gitlab.com/pycqa/flake8
     rev: 3.9.2
     hooks:


### PR DESCRIPTION
I see that black was commented out, I vote to put it back, not sure why was it removed. I believe it’s a good formatter and reduces a lot of overhead by solving some formatting issues. I just updated the version to the latest release 22.3.0. 
I also propose to include autoflake. Autoflake is great to remove unused imports and variables. I’m just submitting unused imports right now, but open to discuss of the idea of unused-variables too. 
These two hooks together can speed up the process of automatic cleaning flake8 constraints