### PR TITLE
Stub runtime dependencies

### DIFF
--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -12,6 +12,7 @@ package_dir =
     =src
 packages=find:
 # Runtime dependencies
+# For more info see https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#declaring-required-dependency
 install_requires = 
 
 [options.packages.find]

--- a/{{ cookiecutter.repo_name }}/setup.cfg
+++ b/{{ cookiecutter.repo_name }}/setup.cfg
@@ -11,9 +11,15 @@ license_files = LICENSE
 package_dir =
     =src
 packages=find:
+# Runtime dependencies
+install_requires = 
 
 [options.packages.find]
 where=src
+
+# Dependencies for specific functionality
+# [options.extras_require]
+# dev = sphinx
 
 [flake8]
 # Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html


### PR DESCRIPTION
Closes #31.

`install_requires` is active but set to nothing so users can fill it in right away.

Extras are stubbed out, but commented so they can be activated if required.