### PR TITLE
Update tests to reflect post hook scripts

### DIFF
--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -74,9 +74,10 @@ def test_is_py_pkg(cookies, inp_using_r: str) -> None:
     # Code should be in a src directory
     assert result.project_path.joinpath('src').exists()
 
-    # Setup and TOML files needs to exist
-    assert result.project_path.joinpath('setup.cfg').exists()
-    assert result.project_path.joinpath('pyproject.toml').exists()
+    # Setup and TOML files needs to exist for Python only
+    if inp_using_r == "No":
+        assert result.project_path.joinpath('setup.cfg').exists()
+        assert result.project_path.joinpath('pyproject.toml').exists()
 
 
 @pytest.mark.parametrize("inp_using_r", ["No", "Yes"])

--- a/{{ cookiecutter.repo_name }}/docs/conf.py
+++ b/{{ cookiecutter.repo_name }}/docs/conf.py
@@ -29,7 +29,7 @@ extensions = [
     "sphinx.ext.autosectionlabel",
     "sphinx.ext.autosummary",
     "sphinx.ext.napoleon",
-    "autoapi.extension",
+    {% if cookiecutter.using_R == "No" %}"autoapi.extension",{% endif %}
     "myst_parser",
     "sphinx.ext.todo",
 ]
@@ -213,6 +213,7 @@ myst_enable_extensions = [
 # Show TODOs in the output
 todo_include_todos = True
 
+{% if cookiecutter.using_R == "No" %} 
 # -- Options for autoapi ---------------------------------------------------------------
 
 # Set the source code language to generage API docs for (defaults to Python)
@@ -220,3 +221,4 @@ todo_include_todos = True
 
 # Where to look for source code
 autoapi_dirs=['../src']
+{% endif %}


### PR DESCRIPTION
Adjusting the build to reflect result of introduced post-hook cleanups.

This is only required because the tests and the post hooks were introduced on somewhat competing timelines. Going forward the two should work together nicely.