### PR TITLE
Don't track arbitrary subfolders under `data/`

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitignore
+++ b/{{ cookiecutter.repo_name }}/.gitignore
@@ -862,7 +862,6 @@ data/*
 
 # Ignore the contents of the `data` sub-folders, except for their `.gitkeep` files; adapted from
 # https://stackoverflow.com/a/20652768
-!data/**/
 data/external/*
 data/raw/*
 data/interim/*


### PR DESCRIPTION
I'm not clear on what the original rationale for this is (it appears to be second- or third-hand code from another source?), but out of an abundance of caution I think it'd be better to remove it.