### PR TITLE
Update pre-commit hooks

### DIFF
--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
   - repo: https://github.com/kynan/nbstripout
-    rev: 0.4.0
+    rev: 0.6.1
     hooks:
       - id: nbstripout
         name: nbstripout - Strip outputs from notebooks (auto-fixes)
@@ -10,7 +10,7 @@ repos:
           - --extra-keys
           - "metadata.colab metadata.kernelspec metadata.metadata.interpreter cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.0.1
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
         name: Check for files larger than 5 MB
@@ -21,7 +21,7 @@ repos:
       - id: trailing-whitespace
         name: Check for trailing whitespaces (auto-fixes)
   - repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort - Sort Python imports (auto-fixes)
@@ -29,38 +29,38 @@ repos:
         args: [ "--profile", "black", "--filter-files" ]
   # Unclear if black is going to be used.
   - repo: https://github.com/psf/black
-    rev: 22.3.0 # Replace by any tag/version: https://github.com/psf/black/tags
+    rev: 23.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
     hooks:
       - id: black
         name: black - consistent Python code formatting (auto-fixes)
         language_version: python # Should be a command that runs python3.6+
   - repo: https://github.com/myint/autoflake
-    rev: v1.4
+    rev: v2.0.2
     hooks:
       - id: autoflake
         args: ['--in-place', '--remove-all-unused-imports', '--ignore-init-module-imports']
-  - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.0.0
     hooks:
       - id: flake8
         name: flake8 - Python linting
   - repo: https://github.com/nbQA-dev/nbQA
-    rev: 0.12.0
+    rev: 1.6.3
     hooks:
       - id: nbqa-isort
         name: nbqa-isort - Sort Python imports (notebooks; auto-fixes)
         args: [ --nbqa-mutate ]
-        additional_dependencies: [ isort==5.8.0 ]
+        additional_dependencies: [ isort==5.12.0 ]
       # - id: nbqa-black
       #   name: nbqa-black - consistent Python code formatting (notebooks; auto-fixes)
       #   args: [ --nbqa-mutate ]
-      #   additional_dependencies: [ black==21.5b2 ]
+      #   additional_dependencies: [ black==23.1.0 ]
       # Disabled for now until it's clear how to add noqa to specific cells of a Jupyter notebook
       #- id: nbqa-flake8
       #  name: nbqa-flake8 - Python linting (notebooks)
-      #  additional_dependencies: [ flake8==3.9.2 ]
+      #  additional_dependencies: [ flake8==6.0.0 ]
   - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.0.3
+    rev: v1.4.0
     hooks:
       - id: detect-secrets
         name: detect-secrets - Detect secrets in staged code
@@ -79,7 +79,7 @@ repos:
 {% if cookiecutter.using_R == "Yes" %}
   # R specific hooks: https://github.com/lorenzwalthert/precommit
   - repo: https://github.com/lorenzwalthert/precommit
-    rev: v0.1.3
+    rev: v0.3.2.9007
     hooks:
       - id: style-files
         name: Style files using styler


### PR DESCRIPTION
- Bump all hooks to the latest versions using `pre-commit autoupdate` command. As a result, unsuccessful pre-commit jobs in GitLab CI caused by the outdated `isort` version are resolved.
- Closes #45 