### PR TITLE
Add test stage to gitlab-ci

### DIFF
--- a/{{ cookiecutter.repo_name }}/.gitlab-ci.yml
+++ b/{{ cookiecutter.repo_name }}/.gitlab-ci.yml
@@ -1,6 +1,7 @@
 stages:
-  - pypkg
   - codecheck
+  - pypkg
+  - test
 
 
 # Prevent detached workflows on merge requests
@@ -53,6 +54,31 @@ python package build:
     paths:
       - "*.tar.*"
       - "*.whl"
+
+# -------------------------------------------------------------------------------------
+# Run unit tests against the built package
+# -------------------------------------------------------------------------------------
+python unit tests:
+  stage: test
+  extends: .python:base
+  dependencies:
+    - python package build
+  variables:
+    COVERAGE_FILE: ".coverage-${CI_JOB_NAME}"
+  before_script:
+  - pip install --disable-pip-version-check pytest-cov
+  - pip install --disable-pip-version-check *.whl
+  script:
+  - coverage run -m pytest tests
+  - coverage report -m
+  - coverage xml
+  coverage: '/(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/'
+  artifacts:
+    reports:
+      coverage_report:
+        coverage_format: cobertura
+        path: coverage.xml
+
  {%- endif %}
 
 # ------------------------------------------------------------------------------------

--- a/{{ cookiecutter.repo_name }}/.gitlab-ci.yml
+++ b/{{ cookiecutter.repo_name }}/.gitlab-ci.yml
@@ -64,20 +64,17 @@ python unit tests:
   dependencies:
     - python package build
   variables:
-    COVERAGE_FILE: ".coverage-${CI_JOB_NAME}"
+    COVERAGE_FILE: "report.xml"
   before_script:
-  - pip install --disable-pip-version-check pytest-cov
-  - pip install --disable-pip-version-check *.whl
+  - pip install --disable-pip-version-check pytest pytest-cov
+  - pip install --disable-pip-version-check  --find-links {{ cookiecutter.__pypkg }}
   script:
-  - coverage run -m pytest tests
-  - coverage report -m
-  - coverage xml
+  - pytest --junitxml=${COVERAGE_FILE} --cov={{ cookiecutter.__pypkg }}
   coverage: '/(?i)total.*? (100(?:\.0+)?\%|[1-9]?\d(?:\.\d+)?\%)$/'
   artifacts:
+    when: always
     reports:
-      coverage_report:
-        coverage_format: cobertura
-        path: coverage.xml
+      junit: ${COVERAGE_FILE}
 
  {%- endif %}
 


### PR DESCRIPTION
Closes #18 

Assumes using `pytest` as the testing framework, although pytest will also run `unittest` tests from stdlib. I'm unsure how R deals with test coverage so that is excluded from this solution.

Relied on [GitLab docs](https://docs.gitlab.com/ee/ci/testing/code_coverage.html#test-coverage-examples) for the matching string. Solution also produces an XML report of the test results which will be [rendered in GitLab as well](https://docs.gitlab.com/ee/ci/testing/unit_test_reports.html).