### PR TITLE
Env selection

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -6,6 +6,7 @@
 
     "using_R": ["No", "Yes"],
     "VCS": ["Gitlab", "Github"],
+    "environment": ["conda", "venv"],
 
     "__pypkg": "{{ cookiecutter.repo_name.replace('-', '_') }}",
 

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -16,6 +16,8 @@ REMOVE_PATHS = [
     '{% if cookiecutter.using_R == "Yes" %} tests/test_cli.py {% endif %}',
     '{% if cookiecutter.using_R == "Yes" %} src/{{ cookiecutter.__pypkg }} {% endif %}',
     '{% if cookiecutter.VCS != "Gitlab" %} .gitlab-ci.yml {% endif %}',
+    '{% if cookiecutter.environment != "conda" %} conda-envs {% endif %}',
+    '{% if cookiecutter.environment != "conda" %} environment.yml {% endif %}',
 ]
 
 for item in REMOVE_PATHS:

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -77,3 +77,19 @@ def test_is_py_pkg(cookies, inp_using_r: str) -> None:
     # Setup and TOML files needs to exist for Python only
     if inp_using_r == "No":
         assert result.project_path.joinpath('pyproject.toml').exists()
+
+
+@pytest.mark.parametrize("environment", ["conda", "venv"])
+def test_target_env(cookies, environment: str) -> None:
+    """Validate conda support renders appropriately."""
+    result = cookies.bake(extra_context={"environment": environment})
+
+    # For conda environments there should be some stubbed files
+    conda_envs_found = result.project_path.joinpath("conda-envs").exists()
+    conda_env_stub = result.project_path.joinpath("environment.yml").exists()
+    if environment == "conda":
+        assert conda_envs_found == True
+        assert conda_env_stub == True
+    else:
+        assert conda_envs_found == False
+        assert conda_env_stub == False


### PR DESCRIPTION
Asks the user if they are targetting a `conda` or `venv` deployment environment then removes any conda specific templates if they pick `venv`. No changes are made to files if they pick `conda`.

This purely a convenience operation to reduce the startup/cleaning that users need to do if they are not targeting a conda environment.