### PR TITLE
Adopt ruff for linting and formatting

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-added-large-files
+        name: Check for large files
+      - id: end-of-file-fixer
+        name: Check for a blank line at the end of scripts (auto-fixes)
+        exclude: '\.Rd'
+      - id: check-toml
+      - id: check-json
+      - id: check-yaml
+        args: [ --allow-multiple-documents ]
+      - id: trailing-whitespace
+        name: Check for trailing whitespaces (auto-fixes)
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.4.0
+    hooks:
+      - id: detect-secrets
+        name: detect-secrets - Detect secrets in staged code
+        args: [ "--baseline", ".secrets.baseline" ]
+        exclude: .*/tests/.*|^\.cruft\.json$

--- a/environment.yml
+++ b/environment.yml
@@ -2,15 +2,13 @@ channels:
    - defaults
    - conda-forge
 dependencies:
-  - autoflake
-  - black
   - cruft
-  - flake8
   - myst-parser
   - pip
   - pre-commit
   - pytest
   - pytest-cov
+  - ruff
   - sphinx
   - sphinx-autoapi
   - sphinx-intl

--- a/{{ cookiecutter.repo_name }}/.flake8
+++ b/{{ cookiecutter.repo_name }}/.flake8
@@ -1,9 +1,0 @@
-[flake8]
-# Rule definitions: http://flake8.pycqa.org/en/latest/user/error-codes.html
-# D203: 1 blank line required before class docstring
-# W503: line break before binary operator
-exclude = .git,venv*,__pycache__,node_modules,bower_components,migrations,src/conf.py
-ignore = D203,W503
-max-complexity = 9
-max-line-length = 88
-extend-ignore = E203

--- a/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
+++ b/{{ cookiecutter.repo_name }}/.pre-commit-config.yaml
@@ -1,14 +1,6 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 repos:
-  - repo: https://github.com/kynan/nbstripout
-    rev: 0.6.1
-    hooks:
-      - id: nbstripout
-        name: nbstripout - Strip outputs from notebooks (auto-fixes)
-        args:
-          - --extra-keys
-          - "metadata.vscode.interpreter.hash metadata.colab metadata.kernelspec metadata.metadata.interpreter cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.4.0
     hooks:
@@ -21,45 +13,24 @@ repos:
       - id: check-toml
       - id: trailing-whitespace
         name: Check for trailing whitespaces (auto-fixes)
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.1.7
     hooks:
-      - id: isort
-        name: isort - Sort Python imports (auto-fixes)
-        types: [ cython, pyi, python ]
-        args: [ "--profile", "black", "--filter-files" ]
-  # Unclear if black is going to be used.
-  - repo: https://github.com/psf/black
-    rev: 23.1.0 # Replace by any tag/version: https://github.com/psf/black/tags
+      - id: ruff
+        types_or: [ python, pyi, jupyter ]
+        args: [ --fix ]
+      - id: ruff-format
+        types_or: [ python, pyi, jupyter ]
+  # Helps to ensure no results get leaked into a commit.
+  # Also cleans the notebook to avoid false secret detection.
+  - repo: https://github.com/kynan/nbstripout
+    rev: 0.6.1
     hooks:
-      - id: black
-        name: black - consistent Python code formatting (auto-fixes)
-        language_version: python # Should be a command that runs python3.6+
-  - repo: https://github.com/myint/autoflake
-    rev: v2.0.2
-    hooks:
-      - id: autoflake
-        args: ['--in-place', '--remove-all-unused-imports', '--ignore-init-module-imports']
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        name: flake8 - Python linting
-  - repo: https://github.com/nbQA-dev/nbQA
-    rev: 1.6.3
-    hooks:
-      - id: nbqa-isort
-        name: nbqa-isort - Sort Python imports (notebooks; auto-fixes)
-        args: [ --nbqa-mutate ]
-        additional_dependencies: [ isort==5.12.0 ]
-      # - id: nbqa-black
-      #   name: nbqa-black - consistent Python code formatting (notebooks; auto-fixes)
-      #   args: [ --nbqa-mutate ]
-      #   additional_dependencies: [ black==23.1.0 ]
-      # Disabled for now until it's clear how to add noqa to specific cells of a Jupyter notebook
-      #- id: nbqa-flake8
-      #  name: nbqa-flake8 - Python linting (notebooks)
-      #  additional_dependencies: [ flake8==6.0.0 ]
+      - id: nbstripout
+        name: nbstripout - Strip outputs from notebooks (auto-fixes)
+        args:
+          - --extra-keys
+          - "metadata.vscode.interpreter.hash metadata.colab metadata.kernelspec metadata.metadata.interpreter cell.metadata.colab cell.metadata.executionInfo cell.metadata.id cell.metadata.outputId"
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.4.0
     hooks:

--- a/{{ cookiecutter.repo_name }}/conda-envs/environment.{{ cookiecutter.repo_name }}.yml
+++ b/{{ cookiecutter.repo_name }}/conda-envs/environment.{{ cookiecutter.repo_name }}.yml
@@ -13,9 +13,7 @@ dependencies:
   - myst-parser
   - pre-commit
   - cruft
-  - flake8
-  - black
-  - autoflake
+  - ruff
   - pre-commit
   - build
   - twine

--- a/{{ cookiecutter.repo_name }}/environment.yml
+++ b/{{ cookiecutter.repo_name }}/environment.yml
@@ -12,9 +12,7 @@ dependencies:
   - myst-parser
   - pre-commit
   - cruft
-  - flake8
-  - black
-  - autoflake
+  - ruff
   - pre-commit
   - build
   - twine

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -69,7 +69,7 @@ target-version = "py310"
 # Which rules to turn on
 select = ["F", "E", "W", "C", "I", "N", "D", "YTT", "ANN", "BLE", "B", "A", "PTH", "PD"]
 # Selectively ignore specific rules (some rules conflict)
-ignore = ["D203", "D211", "D212"]
+ignore = ["D203", "D211", "D212", "PD901"]
 
 # Try to fix all enabled rules
 fixable = [ "ALL" ]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -10,12 +10,11 @@ readme = "README.md"
 keywords = ["one", "two"]
 license = {text = "MIT"}
 # Set the minimum version of Python required to run the code
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
 ]
 dynamic = ["version"]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -84,16 +84,3 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 # to be tuned for the project.
 # See https://en.wikipedia.org/wiki/Cyclomatic_complexity for more on complexity.
 max-complexity = 9
-
-[tool.ruff.format]
-# Like Black, use double quotes for strings.
-quote-style = "double"
-
-# Like Black, indent with spaces, rather than tabs.
-indent-style = "space"
-
-# Like Black, respect magic trailing commas.
-skip-magic-trailing-comma = false
-
-# Like Black, automatically detect the appropriate line ending.
-line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -48,3 +48,49 @@ write_to = "src/{{ cookiecutter.__pypkg }}/_version.py"
 
 [tool.pytest.ini_options]
 pythonpath = [ "src" ]
+
+[tool.ruff]
+# Exclude some directories from processing
+exclude = [
+    ".git",
+    ".venv",
+    "build",
+    "dist",
+    "venv",
+]
+
+# Same settings as Black
+line-length = 88
+indent-width = 4
+
+# Python 3.10 is the current corporate standard
+target-version = "py310"
+
+[tool.ruff.lint]
+# Which rules to turn on
+select = ["F", "E", "W", "C", "I", "N", "D", "YTT", "ANN", "BLE", "B", "A", "PTH", "PD"]
+# Selectively ignore specific rules (some rules conflict)
+ignore = ["D203", "D211", "D212"]
+
+# Try to fix all enabled rules
+fixable = [ "ALL" ]
+unfixable = []
+
+# Allow unused variables when underscore-prefixed.
+dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
+
+[tool.ruff.mccabe]
+max-complexity = 9
+
+[tool.ruff.format]
+# Like Black, use double quotes for strings.
+quote-style = "double"
+
+# Like Black, indent with spaces, rather than tabs.
+indent-style = "space"
+
+# Like Black, respect magic trailing commas.
+skip-magic-trailing-comma = false
+
+# Like Black, automatically detect the appropriate line ending.
+line-ending = "auto"

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -79,6 +79,10 @@ unfixable = []
 dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
 
 [tool.ruff.mccabe]
+# Data processing can end up with multiple if-elif-else statements. Allow liberal
+# control flow, but block overly complex structures. This isn't foolproof so may need
+# to be tuned for the project.
+# See https://en.wikipedia.org/wiki/Cyclomatic_complexity for more on complexity.
 max-complexity = 9
 
 [tool.ruff.format]

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools >= 40.6.0", "wheel", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=64", "wheel", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]


### PR DESCRIPTION
Fixes #67 and updates minimum Python version to 3.10

Flake 8 and Black configurations are generally ported directly. Some additional linting rules are also introduced for things we didn't adopt previously in an attempt to keep plugins to minimum:

* PEP8 naming conventions for classes, functions, variables, etc. (see [pep8-naming](https://docs.astral.sh/ruff/rules/#pep8-naming-n))
* Enforcement of docstring usage (see [pydocstyle](https://docs.astral.sh/ruff/rules/#pydocstyle-d))
* Unsafe python version checks (see [flake8-2020](https://docs.astral.sh/ruff/rules/#flake8-2020-ytt))
* Require type annotations (see [flake8-annotations](https://docs.astral.sh/ruff/rules/#flake8-annotations-ann))
* Disallow blind except (see [flake8-blind-except](https://docs.astral.sh/ruff/rules/#flake8-blind-except-ble))
* Check for common bugs (see [flake8-bugbear](https://docs.astral.sh/ruff/rules/#flake8-bugbear-b))
* Check for built-in shadowing (see [flake8-builtins](https://docs.astral.sh/ruff/rules/#flake8-builtins-a))
* Use `pathlib` over `os.path` (see [flake8-use-pathlib](https://docs.astral.sh/ruff/rules/#flake8-use-pathlib-pth))
* Linting for pandas code (see [pandas-vet](https://docs.astral.sh/ruff/rules/#pandas-vet-pd))