### PR TITLE
Exclude `docs/conf.py` from linting

### DIFF
--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -56,6 +56,7 @@ exclude = [
     "build",
     "dist",
     "venv",
+    "docs",
 ]
 
 # Same settings as Black

--- a/{{ cookiecutter.repo_name }}/pyproject.toml
+++ b/{{ cookiecutter.repo_name }}/pyproject.toml
@@ -56,7 +56,7 @@ exclude = [
     "build",
     "dist",
     "venv",
-    "docs",
+    "docs/conf.py",
 ]
 
 # Same settings as Black


### PR DESCRIPTION
Ruff currently complains about `docs/conf.py`, but since this is auto-generated we should probably ignore it.

I ran into this while trying to use the template today. Alternatives could include loosening the set of rules we enforce or having more fine-grained exclusions under the docs folder.